### PR TITLE
Fix typos in the docs

### DIFF
--- a/doc/user/library.rst
+++ b/doc/user/library.rst
@@ -104,7 +104,7 @@ it with Dantalian instead of using ``dantalian convert``.
 Because converted directories are all kept in one location, no two
 converted directories may have the same name.  However, the name of
 the directory Dantalian keeps track of and the name of the symbolic
-link that the user interacts with are independent of eac hoterh.
+link that the user interacts with are independent of each other.
 Thus, if there's a naming conflict, the actual directory can be
 renamed, and the symbolic links follow the naming rules as above.
 

--- a/doc/user/scale.rst
+++ b/doc/user/scale.rst
@@ -53,7 +53,7 @@ The first obstacle that you will likely encounter when scaling Dantalian
 up is size constraints, since everything must reside on one file system.
 This obstacle is encountered once the amount of data you are trying to
 organize exceeds the amount of space of one storage device (say, a 1 TB
-hard disk drive).  This can be circumvented by using LLVM and creating a
+hard disk drive).  This can be circumvented by using LVM and creating a
 virtual file system that spans multiple physical storage devices.
 
 Any time constraints can be ameliorated with additional caching if


### PR DESCRIPTION
I stumbled over a few typos while reading the documentation.
