### PR TITLE
Fix two issues in dtags.py and tagging.py

### DIFF
--- a/src/dantalian/dtags.py
+++ b/src/dantalian/dtags.py
@@ -50,7 +50,7 @@ def write_tag(file, tagname):
 
 def write_tags(file, tags):
     """Write a list of tags to a file object."""
-    file.seek()
+    file.seek(0)
     for tag in tags:
         write_tag(file, tag)
     file.truncate()

--- a/src/dantalian/tagging.py
+++ b/src/dantalian/tagging.py
@@ -47,6 +47,9 @@ def untag(rootpath, path, directory):
         directory: Directory path.
     """
     target = path
+    to_unlink = []
     for filepath in pathlib.listdirpaths(directory):
         if posixpath.samefile(target, filepath):
-            base.unlink(rootpath, filepath)
+            to_unlink.append(filepath)
+    for filepath in to_unlink:
+        base.unlink(rootpath, filepath)


### PR DESCRIPTION
In dtags.py, the function `write_tags` has a line
`file.seek()`
which indeed raises an error
`TypeError: seek() takes at least 1 argument (0 given)`
You have probably meant `file.seek(0)` there. The first commit makes the change.

In tagging.py, the function `untag` behaves poorly. It may delete `target` file somewhere in the middle of the loop, and then try to compare `target` with another file, which raises an error like
`FileNotFoundError: [Errno 2] No such file or directory: 'hh'`
In the second commit, I've made this function first collect the files to unlink, and then unlink the collected files.

I've tested the changed library on my computer, the functions seems to work fine now.